### PR TITLE
Install Redis only if the host is Pantheon

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,7 +290,7 @@ The add-on automatically installs and configures:
 - **Terminus** for Pantheon API access (when using Pantheon)
 - **Theme development tools** (Node.js, NPM)
 - **Critical CSS generation tools**
-- **Redis add-on** for caching
+- **Redis add-on** for Pantheon caching (conditionally installed during `ddev project-configure`)
 - **Multi-provider API tools** for hosting platform integration
 
 ## WordPress-Specific Features

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ ddev project-init
 - **Block Development** - WordPress block scaffolding and tooling
 - **E2E Testing** - Cypress integration with user management
 - **Performance Tools** - Critical CSS generation and optimization
-- **Service Integration** - Redis support for object caching
+- **Service Integration** - Redis support for Pantheon object caching
 
 ## 📚 Documentation
 

--- a/commands/host/project-configure
+++ b/commands/host/project-configure
@@ -126,6 +126,24 @@ echo "----------------------------------"
 HOST_PROVIDER=$(select_option "Select your hosting provider:" "pantheon" "wpengine" "kinsta")
 echo "✓ Selected: $HOST_PROVIDER"
 
+# Install Redis for Pantheon (Pantheon requires Redis for object caching)
+if [[ "$HOST_PROVIDER" == "pantheon" ]]; then
+    echo ""
+    echo "📦 Installing Redis add-on for Pantheon..."
+    set +e  # Allow command to fail gracefully
+    if ddev add-on get ddev/ddev-redis 2>&1; then
+        echo "✅ Redis add-on installed successfully"
+        # Add to gitignore if not already present
+        if [ -f ".gitignore" ]; then
+            grep -q "settings.ddev.redis.php" .gitignore || echo "settings.ddev.redis.php" >> .gitignore
+        fi
+    else
+        echo "⚠️  Redis add-on installation failed (likely GitHub API rate limit)"
+        echo "   You can install it manually later with: ddev add-on get ddev/ddev-redis"
+    fi
+    set -e  # Re-enable strict error checking
+fi
+
 # Get hosting-specific configuration
 echo ""
 case "$HOST_PROVIDER" in

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ This add-on provides:
 - **Database Management**: Smart refresh system with 12-hour backup detection
 - **Theme Development**: Node.js, NPM, and build tools with file watching
 - **Security & Performance**: Nginx configuration with headers and optimization
-- **Services Integration**: Redis for object caching via official DDEV add-on
+- **Services Integration**: Redis for Pantheon object caching (auto-installed for Pantheon)
 - **Environment Configuration**: Clean configuration system using environment variables
 
 ## Quick Start

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -181,7 +181,7 @@ ddev restart
 
 ### Remove the Add-on
 ```bash
-# Remove the add-on completely (includes Redis and all 26 commands)
+# Remove the add-on completely (includes Redis for Pantheon and all 26 commands)
 ddev add-on remove kanopi-wp
 
 # Restart DDEV to apply changes

--- a/docs/pull-requests.md
+++ b/docs/pull-requests.md
@@ -31,7 +31,7 @@ I need to create a pull request for adding the ddev-kanopi-wp add-on to this Wor
    - Always consolidate to simplest workflow (avoid redundant ddev start before ddev init)
 5. Include all DDEV-specific elements:
    - Custom commands available (theme, database, hosting integration)
-   - Service integrations (Redis for object caching)
+   - Service integrations (Redis for Pantheon object caching, if applicable)
    - Development workflow improvements
    - Multi-environment support details
 6. Create the actual PR with proper git commands:
@@ -87,7 +87,7 @@ This PR adds DDEV as the primary local development environment using the [ddev-k
 - [x] Critical CSS generation: `ddev critical-install`
 
 ### Service Integration
-- [x] Redis for object caching (auto-configured)
+- [x] Redis for object caching (auto-configured for Pantheon)
 
 ### Documentation Updates
 - [x] Updated README.md with DDEV as primary setup option
@@ -118,7 +118,7 @@ This PR adds DDEV as the primary local development environment using the [ddev-k
 ### ✅ Service Access
 - [ ] WordPress site accessible at `https://[project-name].ddev.site`
 - [ ] Admin accessible via `ddev wp-open admin`
-- [ ] Redis integration functioning
+- [ ] Redis integration functioning (Pantheon only)
 
 ### ✅ Testing Integration
 - [ ] Cypress installs and runs successfully
@@ -300,7 +300,7 @@ New team members will need:
 - [ ] Database operations function correctly
 - [ ] Theme development workflow operational
 - [ ] All custom commands available and working
-- [ ] Services (Redis) accessible
+- [ ] Services (Redis for Pantheon) accessible
 - [ ] Hosting provider integration functional
 ```
 

--- a/docs/readme-updates.md
+++ b/docs/readme-updates.md
@@ -282,7 +282,7 @@ Document additional services:
 ```markdown
 ## Integrated Services
 
-- **Redis**: Object caching (auto-configured)
+- **Redis**: Object caching (auto-configured for Pantheon only)
 - **Mail Capture**: Development email testing
 ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -339,17 +339,19 @@ ddev exec chown -R www-data:www-data wp-content/themes/[theme]/assets/
 
 ## Service Integration Issues
 
-### Redis Issues
+### Redis Issues (Pantheon Only)
 
 #### Redis Service Not Available
 ```bash
 # Check service status
 ddev describe
 
-# Reinstall Redis if needed
+# Reinstall Redis if needed (Pantheon only - auto-installed during project-configure)
 ddev add-on get ddev/ddev-redis
 ddev restart
 ```
+
+**Note**: Redis is only installed automatically for Pantheon hosting. If you're using WPEngine or Kinsta, Redis is not required.
 
 ## Getting Help
 

--- a/install.yaml
+++ b/install.yaml
@@ -26,21 +26,12 @@ pre_install_actions:
 post_install_actions:  
 
 - |
-  #ddev-description: Install required DDEV add-ons
-  # Install DDEV add-ons with graceful failure handling for CI environments
-  set +e  # Allow commands to fail without stopping the script
+  #ddev-description: DDEV add-on installation
+  # Note: Redis is now installed conditionally in project-configure for Pantheon only
   echo ""
-  echo "📦 Installing Redis add-on..."
-  if ddev add-on get ddev/ddev-redis 2>&1; then
-    echo "✅ Redis add-on installed successfully"
-  else
-    echo "⚠️  Redis add-on installation failed (likely GitHub API rate limit in CI)"
-    echo "   You can install it manually later with: ddev add-on get ddev/ddev-redis"
-  fi
-  set -e  # Re-enable strict error checking
+  echo "📦 DDEV add-on installation"
+  echo "   Redis will be installed automatically for Pantheon during project-configure"
   echo ""
-  echo "Ignore DDEV add-on settings files"
-  echo "settings.ddev.redis.php" >> ../.gitignore
 
 - |
   #ddev-description: WordPress configuration setup
@@ -285,7 +276,7 @@ removal_actions:
   
   echo ""
   echo "✅ Kanopi WordPress Add-on removed successfully!"
-  echo "   • Redis add-on uninstalled"
+  echo "   • Redis add-on uninstalled (if installed)"
   echo "   • All 26 custom commands removed"
   echo "   • Nginx proxy configuration removed"
   echo "   • Environment variables preserved (remove manually if needed)"


### PR DESCRIPTION
## Description

- [x] Was AI used in this pull request?

Only Pantheon has Redis by default, so lets not install the extra container is we don't need it.