### PR TITLE
Optimize Critical CSS installation using webimage_extra_packages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,9 +289,19 @@ The add-on automatically installs and configures:
 - **Cypress** for E2E testing
 - **Terminus** for Pantheon API access (when using Pantheon)
 - **Theme development tools** (Node.js, NPM)
-- **Critical CSS generation tools**
+- **Critical CSS generation tools** with pre-installed Chromium dependencies
 - **Redis add-on** for Pantheon caching (conditionally installed during `ddev project-configure`)
 - **Multi-provider API tools** for hosting platform integration
+
+### Critical CSS Dependencies
+
+The addon automatically configures `webimage_extra_packages` in `.ddev/config.yaml` to pre-install Chromium and its dependencies. This eliminates the need for `apt-get` installation during `ddev critical-install`, significantly speeding up Critical CSS setup.
+
+**Packages installed:**
+- Chromium (headless browser for Critical CSS generation)
+- 32 Chromium dependencies (libgbm1, libasound2, libatk1.0-0, libc6, libcairo2, libcups2, libdbus-1-3, libexpat1, libfontconfig1, libgcc1, libgconf-2-4, libgdk-pixbuf2.0-0, libglib2.0-0, libgtk-3-0, libnspr4, libpango-1.0-0, libpangocairo-1.0-0, libstdc++6, libx11-6, libx11-xcb1, libxcb1, libxcursor1, libxdamage1, libxext6, libxfixes3, libxi6, libxrandr2, libxrender1, libxss1, libxtst6, libnss3)
+
+These packages are installed once during `ddev start` or `ddev restart` rather than every time `critical-install` runs, providing significant performance improvements.
 
 ## WordPress-Specific Features
 

--- a/commands/web/critical-install
+++ b/commands/web/critical-install
@@ -41,13 +41,22 @@ FULL_THEME_PATH="/var/www/html/${DOCROOT}/${THEME_PATH}"
 # Abort if anything fails
 set -e
 
-# Critical.
-echo -e "\n ${hospital} ${yellow} Installing tools needed for Critical CSS${NC} ${hospital}"
+# Critical CSS dependencies verification
+echo -e "\n ${hospital} ${yellow} Verifying Critical CSS dependencies${NC} ${hospital}"
 echo -e "${green}${divider}${NC}"
-sudo apt-get --allow-releaseinfo-change update
-sudo apt-get install -yq --no-install-recommends libgbm1 libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 libnss3
-# Add this for M chips.
-sudo apt-get install -yq --no-install-recommends chromium
+
+# Check if chromium is installed (indicates webimage_extra_packages are configured)
+if ! command -v chromium &> /dev/null; then
+    echo -e "\n${yellow}Warning: Chromium not found.${NC}"
+    echo -e "Critical CSS packages should be pre-installed via webimage_extra_packages."
+    echo -e "${yellow}Please run 'ddev restart' to install required packages.${NC}"
+    echo ""
+    echo "If issues persist, check that webimage_extra_packages is configured in .ddev/config.yaml"
+    echo "The addon should have added these automatically during installation."
+    exit 1
+fi
+
+echo -e "\n${check} ${green}Critical CSS dependencies verified${NC}"
 
 # Check if theme directory exists
 if [ ! -d "${FULL_THEME_PATH}" ]; then

--- a/install.yaml
+++ b/install.yaml
@@ -146,6 +146,73 @@ post_install_actions:
     echo "📝 No Pantheon mu-plugin loader found - no action needed"
   fi
 
+- |
+  #ddev-description: Configure Critical CSS dependencies
+  echo ""
+  echo "📦 Configuring Critical CSS dependencies in config.yaml..."
+
+  # Find config.yaml file
+  CONFIG_FILE=""
+  for path in "../../config.yaml" "../../../config.yaml" "config.yaml" "../config.yaml"; do
+    if [ -f "$path" ]; then
+      CONFIG_FILE="$path"
+      break
+    fi
+  done
+
+  if [ -z "$CONFIG_FILE" ]; then
+    echo "⚠️  Could not find config.yaml - Critical CSS packages not configured"
+  else
+    # Check if webimage_extra_packages already exists
+    if grep -q "^webimage_extra_packages:" "$CONFIG_FILE"; then
+      echo "📝 webimage_extra_packages already exists in config.yaml"
+      echo "   Please manually add Critical CSS dependencies if needed"
+      echo "   See documentation for package list"
+    else
+      # Append webimage_extra_packages to config.yaml
+      cat >> "$CONFIG_FILE" << 'EOF'
+
+# Critical CSS dependencies (added by ddev-kanopi-wp)
+# These packages are required for ddev critical-install and ddev critical-run
+webimage_extra_packages:
+  - libgbm1
+  - libasound2
+  - libatk1.0-0
+  - libc6
+  - libcairo2
+  - libcups2
+  - libdbus-1-3
+  - libexpat1
+  - libfontconfig1
+  - libgcc1
+  - libgconf-2-4
+  - libgdk-pixbuf2.0-0
+  - libglib2.0-0
+  - libgtk-3-0
+  - libnspr4
+  - libpango-1.0-0
+  - libpangocairo-1.0-0
+  - libstdc++6
+  - libx11-6
+  - libx11-xcb1
+  - libxcb1
+  - libxcursor1
+  - libxdamage1
+  - libxext6
+  - libxfixes3
+  - libxi6
+  - libxrandr2
+  - libxrender1
+  - libxss1
+  - libxtst6
+  - libnss3
+  - chromium
+EOF
+      echo "✅ Critical CSS dependencies added to config.yaml"
+      echo "   Run 'ddev restart' after installation to install packages"
+    fi
+  fi
+
 # Explain the installed components
 - |
   echo ""
@@ -228,7 +295,21 @@ removal_actions:
   # Remove directory structure
   rm -rf config 2>/dev/null || true
   rm -rf scripts 2>/dev/null || true
-  
+
+  # Remove Critical CSS dependencies from config.yaml
+  echo "🔧 Removing Critical CSS dependencies from config.yaml..."
+  if [ -f "../../config.yaml" ]; then
+    # Create a temporary file without the Critical CSS section
+    awk '
+      /# Critical CSS dependencies \(added by ddev-kanopi-wp\)/ { skip=1; next }
+      /^webimage_extra_packages:/ && skip { in_packages=1; next }
+      in_packages && /^  - / { next }
+      in_packages && !/^  - / { skip=0; in_packages=0 }
+      !skip { print }
+    ' "../../config.yaml" > "../../config.yaml.tmp" && mv "../../config.yaml.tmp" "../../config.yaml"
+    echo "✅ Critical CSS dependencies removed from config.yaml"
+  fi
+
   # Restore Pantheon mu-plugin loader if it was disabled during installation
   # Find config.yaml file for docroot detection
   CONFIG_FILE=""


### PR DESCRIPTION
## Description

This PR significantly improves the performance of Critical CSS setup by moving Chromium and its 32 dependencies from runtime `apt-get` installation to DDEV's `webimage_extra_packages` configuration. This change eliminates the need to run `apt-get update` and install packages every time `ddev critical-install` is executed, resulting in dramatically faster execution times.

### Key Changes:
- **install.yaml**: Automatically configures `webimage_extra_packages` in `.ddev/config.yaml` during addon installation
- **commands/web/critical-install**: Replaces `apt-get install` commands with a verification check for Chromium
- **Removal cleanup**: Properly removes the webimage_extra_packages section when addon is uninstalled
- **Documentation**: Updated CLAUDE.md to document the new approach and performance benefits

### Performance Impact:
- **Before**: `critical-install` runs `apt-get update` + installs 33 packages (~30-60 seconds)
- **After**: `critical-install` verifies Chromium exists (~instant)
- Packages are installed once during `ddev start/restart` instead of every `critical-install` run

### Technical Details:
The addon now appends a `webimage_extra_packages` section to the user's existing `.ddev/config.yaml` during installation, including:
- Chromium (headless browser)
- 32 Chromium dependencies (libgbm1, libasound2, libatk1.0-0, etc.)

If `webimage_extra_packages` already exists in the user's config, the installation process respects it and provides guidance for manual addition.

## Acceptance Criteria
- [x] Critical CSS dependencies are configured via webimage_extra_packages
- [x] critical-install command verifies packages instead of installing them
- [x] Installation adds webimage_extra_packages to config.yaml
- [x] Removal cleanly removes webimage_extra_packages section
- [x] Documentation updated to explain the new approach
- [x] User receives clear error messages if packages aren't installed

## Assumptions
- Users will run `ddev restart` after addon installation to install the packages
- DDEV's `webimage_extra_packages` feature is available (DDEV >= v1.22.0 already required)
- Users who already have `webimage_extra_packages` defined can manually merge the Critical CSS dependencies

## Steps to Validate

### For New Installations:
1. Install the addon: `ddev add-on get kanopi/ddev-kanopi-wp`
2. Verify `webimage_extra_packages` was added to `.ddev/config.yaml`
3. Run `ddev restart` to install packages
4. Run `ddev critical-install` - should complete quickly with verification message
5. Verify Chromium is available: `ddev exec "chromium --version"`

### For Existing Installations:
1. Update the addon: `ddev add-on get kanopi/ddev-kanopi-wp`
2. If `webimage_extra_packages` already exists, manually add Critical CSS packages
3. Run `ddev restart`
4. Test `ddev critical-install` execution speed

### For Removal:
1. Remove addon: `ddev add-on remove kanopi-wp`
2. Verify `webimage_extra_packages` section was removed from `.ddev/config.yaml`
3. Verify any user-added webimage_extra_packages remain intact

## Affected Files
- `install.yaml`: Post-install action to configure webimage_extra_packages
- `install.yaml`: Removal action to clean up webimage_extra_packages
- `commands/web/critical-install`: Replaced apt-get with verification
- `CLAUDE.md`: Added Critical CSS Dependencies documentation section

## Deploy Notes

### Pre-deployment
- [x] No pre-deployment steps required
- [x] This is an addon change, not a site deployment

### Deployment Steps
This change deploys automatically when users:
1. Install the addon: `ddev add-on get kanopi/ddev-kanopi-wp`
2. Update existing installations: `ddev add-on get kanopi/ddev-kanopi-wp` (will show message if webimage_extra_packages exists)
3. Run `ddev restart` to apply webimage_extra_packages changes

**For addon maintainers:**
- [ ] Merge PR to main branch
- [ ] Create new release tag if applicable
- [ ] Update changelog

### Post-deployment
- [ ] Monitor for any issues with webimage_extra_packages conflicts
- [ ] Verify user feedback on installation speed improvements
- [ ] Update documentation site if needed

### Rollback Plan
If issues occur, users can:
1. Revert to previous addon version
2. Manually remove webimage_extra_packages from `.ddev/config.yaml`
3. Run `ddev restart` to revert to clean state
4. The old `critical-install` with apt-get will work as fallback

## Additional Notes

**Benefits:**
- ✅ Dramatically faster `critical-install` execution
- ✅ Uses standard DDEV pattern (webimage_extra_packages)
- ✅ One-time package installation during container build
- ✅ Cleaner command - focuses on theme setup, not system packages

**Considerations:**
- ⚠️ Requires `ddev restart` after installation for packages to be available
- ⚠️ If user has existing `webimage_extra_packages`, they need to manually merge
- ⚠️ Slightly longer initial `ddev start` time (one-time cost)

🤖 Generated with [Claude Code](https://claude.com/claude-code)