### PR TITLE
Update Details for Platform-Specific Information

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@ A comprehensive DDEV add-on that provides Kanopi's battle-tested workflow for Wo
 ## 🚀 Quick Start
 
 ```bash
-# Intialize a project (adjust docroot/database if needed)
+# Intialize a project
+#
+# NOTE: Adjust the docroot/database as needed - for example, to set up
+# a site on WPEngine, the docroot would be 'public'
 ddev config --project-type=wordpress --docroot=web --database=mariadb:10.6
 
 # Install the add-on
@@ -84,7 +87,10 @@ ddev restart
 
 ### New Projects
 ```bash
-# Initialize DDEV (Adjust webroot/database as needed)
+# Intialize DDEV
+#
+# NOTE: Adjust the docroot/database as needed - for example, to set up
+# a site on WPEngine, the docroot would be 'public'
 ddev config --project-type=wordpress --docroot=web --database=mariadb:10.6
 
 # Install add-on

--- a/commands/host/project-configure
+++ b/commands/host/project-configure
@@ -316,6 +316,8 @@ write_local_config_var() {
 # Local configuration for user-specific settings
 # This file is ignored by git to keep personal settings private
 
+# SSH key path - customize this for your user account
+# Example: ~/.ssh/your_key or /Users/username/.ssh/your_key
 web_environment:
   - ${var_name}=${var_value}
 EOF


### PR DESCRIPTION
## Description
Documentation improvements for platform-specific setup requirements.

- [ ] Was AI used in this pull request?

> Clarify docroot requirements for different hosting providers and improve local configuration documentation.

**Current behavior:** README quick start examples don't explain that docroot varies by hosting provider. Local configuration template lacks context about SSH key path customization.

**Updated behavior:** README examples include notes about platform-specific docroot requirements (e.g., WPEngine uses `public`). Local configuration template includes helpful comments about SSH key path customization.

## Acceptance Criteria
* README quick start sections include platform-specific docroot examples
* Local configuration template includes SSH key path guidance
* Documentation remains concise and actionable

## Assumptions
* Users may be setting up projects on different hosting providers
* SSH key path configuration benefits from inline examples

## Steps to Validate
1. Review README.md changes for clarity on docroot configuration
2. Check `commands/host/project-configure` for improved local config template comments
3. Verify documentation follows existing format conventions

## Affected URL
N/A - Documentation only changes

## Deploy Notes
No deployment actions required. Documentation updates only.